### PR TITLE
Single quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ If you'd like to contribute to this collection of snippets, feel free to [submit
 | csrf           | ``{% csrf_token %}``                                  |
 | cycle          | ``{% cycle %}``                                       |
 | debug          | ``{% debug %}``                                       |
-| ext            | ``{% extends "" %}``                                  |
-| extends        | ``{% extends "" %}``                                  |
+| ext            | ``{% extends '' %}``                                  |
+| extends        | ``{% extends '' %}``                                  |
 | filter         | ``{% filter %} {% endfilter %}``                      |
 | firstof        | ``{% firstof %}``                                     |
 | for            | ``{% for in %} {% endfor %}``                         |
@@ -33,7 +33,7 @@ If you'd like to contribute to this collection of snippets, feel free to [submit
 | inc            | ``{% include %}``                                     |
 | include        | ``{% include %}``                                     |
 | load           | ``{% load %}``                                        |
-| now            | ``{% now "" %}``                                      |
+| now            | ``{% now '' %}``                                      |
 | regroup        | ``{% regroup by as %}``                               |
 | spaceless      | ``{% spaceless %} {% endspaceless %}``                |
 | ssi            | ``{% ssi %}``                                         |

--- a/snippets/templates/html.json
+++ b/snippets/templates/html.json
@@ -1,7 +1,7 @@
 {
 	"autoescape": {
 		"prefix": "autoescape",
-		"body": "\r\n{% autoescape ${1:off} %}\r\n\t${2:$SELECTION}\r\n{% endautoescape %}\r\n ",
+		"body": "\r\n{% autoescape ${1:off} %}\r\n\t${2:$SELECTION}\r\n{% endautoescape %}\r\n",
 		"description": "autoescape",
 		"scope": "text.html.django"
 	},
@@ -13,7 +13,7 @@
 	},
 	"blocktrans": {
 		"prefix": "blocktrans",
-		"body": "\r\n{% blocktrans %}\r\n    ${1:$SELECTION}\r\n{% endblocktrans %}\r\n ",
+		"body": "\r\n{% blocktrans %}\r\n\t${1:$SELECTION}\r\n{% endblocktrans %}\r\n",
 		"description": "blocktrans",
 		"scope": "text.html.django"
 	},
@@ -73,19 +73,19 @@
 	},
 	"extrahead": {
 		"prefix": "extrahead",
-		"body": "\r\n{% block extrahead %}\r\n    ${1:$SELECTION}\r\n{% endblock extrahead %}\r\n\t",
+		"body": "\r\n{% block extrahead %}\r\n\t${1:$SELECTION}\r\n{% endblock extrahead %}\r\n\t",
 		"description": "block extrahead",
 		"scope": "text.html.django"
 	},
 	"extrastyle": {
 		"prefix": "extrastyle",
-		"body": "\r\n{% block extrastyle %}\r\n    ${1:$SELECTION}\r\n{% endblock extrastyle %}\r\n\t",
+		"body": "\r\n{% block extrastyle %}\r\n\t${1:$SELECTION}\r\n{% endblock extrastyle %}\r\n\t",
 		"description": "block extrastyle",
 		"scope": "text.html.django"
 	},
 	"filter": {
 		"prefix": "filter",
-		"body": "\r\n{% filter $1 %}\r\n\t${2:$SELECTION}\r\n{% endfilter %}\r\n ",
+		"body": "\r\n{% filter $1 %}\r\n\t${2:$SELECTION}\r\n{% endfilter %}\r\n",
 		"description": "filter",
 		"scope": "text.html.django"
 	},
@@ -259,7 +259,7 @@
 	},
 	"with": {
 		"prefix": "with",
-		"body": "\r\n{% with $1 as $2 %}\r\n    ${3:$SELECTION}\r\n{% endwith %}\r\n\t",
+		"body": "\r\n{% with $1 as $2 %}\r\n\t${3:$SELECTION}\r\n{% endwith %}\r\n\t",
 		"description": "with",
 		"scope": "text.html.django"
 	}

--- a/snippets/templates/html.json
+++ b/snippets/templates/html.json
@@ -61,13 +61,13 @@
 	},
 	"ext": {
 		"prefix": "ext",
-		"body": "{% extends \"${1:$SELECTION}\" %}",
+		"body": "{% extends '${1:$SELECTION}' %}",
 		"description": "extends (ext)",
 		"scope": "text.html.django"
 	},
 	"extends": {
 		"prefix": "extends",
-		"body": "{% extends \"${1:$SELECTION}\" %}",
+		"body": "{% extends '${1:$SELECTION}' %}",
 		"description": "extends",
 		"scope": "text.html.django"
 	},
@@ -157,13 +157,13 @@
 	},
 	"inc": {
 		"prefix": "inc",
-		"body": "{% include ${1:\"$2\"} %}",
+		"body": "{% include ${1:'$2'} %}",
 		"description": "include (inc)",
 		"scope": "text.html.django"
 	},
 	"include": {
 		"prefix": "include",
-		"body": "{% include ${1:\"$2\"} %}",
+		"body": "{% include ${1:'$2'} %}",
 		"description": "include",
 		"scope": "text.html.django"
 	},
@@ -181,7 +181,7 @@
 	},
 	"now": {
 		"prefix": "now",
-		"body": "{% now \"$1\" %}",
+		"body": "{% now '$1' %}",
 		"description": "now",
 		"scope": "text.html.django"
 	},
@@ -205,7 +205,7 @@
 	},
 	"static": {
 		"prefix": "static",
-		"body": "{% static \"${1:$SELECTION}\" %}",
+		"body": "{% static '${1:$SELECTION}' %}",
 		"description": "static",
 		"scope": "text.html.django"
 	},
@@ -235,7 +235,7 @@
 	},
 	"trans": {
 		"prefix": "trans",
-		"body": "{% trans \"${1:$SELECTION}\" %}",
+		"body": "{% trans '${1:$SELECTION}' %}",
 		"description": "trans",
 		"scope": "text.html.django"
 	},


### PR DESCRIPTION
Less code highlighting confusion when using tags inside HTML attrs (which generally use double-quotes).