### PR TITLE
Adding syntax support for django templates

### DIFF
--- a/syntaxes/django-html.json
+++ b/syntaxes/django-html.json
@@ -1,0 +1,338 @@
+{
+    "name": "django-html",
+    "scopeName": "text.html.django",
+    "comment": "Django Template Engine",
+    "fileTypes": [
+        "html"
+    ],
+    "firstLineMatch": "^{% extends [\"'][^\"']+[\"'] %}",
+    "foldingStartMarker": "(<(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(block|filter|for|if|macro|raw))",
+    "foldingStopMarker": "(<\/(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\\b.*?>|{%\\s*(endblock|endfilter|endfor|endif|endmacro|endraw)\\s*%})",
+    "patterns": [
+        {
+            "begin": "{#",
+            "captures": [
+                {
+                    "name": "entity.other.django.delimiter.comment"
+                }
+            ],
+            "end": "#}",
+            "name": "comment.line.django"
+        },
+        {
+            "begin": "{% comment %}",
+            "captures": [
+                {
+                    "name": "entity.other.django.delimiter.comment"
+                }
+            ],
+            "end": "{% endcomment %}",
+            "name": "comment.block.django"
+        },
+        {
+            "begin": "{{",
+            "captures": [
+                {
+                    "name": "entity.other.django.delimiter.variable"
+                }
+            ],
+            "end": "}}",
+            "name": "meta.scope.django.variable",
+            "patterns": [
+                {
+                    "include": "#expression"
+                }
+            ]
+        },
+        {
+            "begin": "{%",
+            "captures": [
+                {
+                    "name": "entity.other.django.delimiter.tag"
+                }
+            ],
+            "end": "%}",
+            "name": "meta.scope.django.tag",
+            "patterns": [
+                {
+                    "include": "#expression"
+                }
+            ]
+        },
+        {
+            "include": "text.html.basic"
+        }
+    ],
+    "repository": {
+        "escaped_char": {
+            "match": "\\\\x[0-9A-F]{2}",
+            "name": "constant.character.escape.hex.django"
+        },
+        "escaped_unicode_char": {
+            "captures": {
+                "1": {
+                    "name": "constant.character.escape.unicode.16-bit-hex.django"
+                },
+                "2": {
+                    "name": "constant.character.escape.unicode.32-bit-hex.django"
+                },
+                "3": {
+                    "name": "constant.character.escape.unicode.name.django"
+                }
+            },
+            "match": "(\\\\U[0-9A-Fa-f]{8})|(\\\\u[0-9A-Fa-f]{4})|(\\\\N\\{[a-zA-Z ]+\\})"
+        },
+        "expression": {
+            "patterns": [
+                {
+                    "captures": {
+                        "1": {
+                            "name": "keyword.control.django"
+                        },
+                        "2": {
+                            "name": "variable.other.django.block"
+                        }
+                    },
+                    "match": "\\s*\\b(block)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\b"
+                },
+                {
+                    "captures": {
+                        "1": {
+                            "name": "keyword.control.django"
+                        },
+                        "2": {
+                            "name": "variable.other.django.filter"
+                        }
+                    },
+                    "match": "\\s*\\b(filter)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\b"
+                },
+                {
+                    "captures": {
+                        "1": {
+                            "name": "keyword.control.django"
+                        },
+                        "2": {
+                            "name": "variable.other.django.test"
+                        }
+                    },
+                    "match": "\\s*\\b(is)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\b"
+                },
+                {
+                    "captures": {
+                        "1": {
+                            "name": "keyword.control.django"
+                        }
+                    },
+                    "match": "(?<=\\{\\%-|\\{\\%)\\s*\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?!\\s*[,=])"
+                },
+                {
+                    "match": "\\b(and|else|if|in|import|not|or|with(out)?\\s+context)\\b",
+                    "name": "keyword.control.django"
+                },
+                {
+                    "match": "\\b(true|false|none)\\b",
+                    "name": "constant.language.django"
+                },
+                {
+                    "match": "\\b(loop|super|self|varargs|kwargs)\\b",
+                    "name": "variable.language.django"
+                },
+                {
+                    "match": "[a-zA-Z_][a-zA-Z0-9_]*",
+                    "name": "variable.other.django"
+                },
+                {
+                    "match": "(\\+|\\-|\\*\\*|\\*|\/\/|\/|%)",
+                    "name": "keyword.operator.arithmetic.django"
+                },
+                {
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.other.django"
+                        },
+                        "2": {
+                            "name": "variable.other.django.filter"
+                        }
+                    },
+                    "match": "(\\|)([a-zA-Z_][a-zA-Z0-9_]*)"
+                },
+                {
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.other.django"
+                        },
+                        "2": {
+                            "name": "variable.other.django.attribute"
+                        }
+                    },
+                    "match": "(\\.)([a-zA-Z_][a-zA-Z0-9_]*)"
+                },
+                {
+                    "begin": "\\[",
+                    "captures": [
+                        {
+                            "name": "punctuation.other.django"
+                        }
+                    ],
+                    "end": "\\]",
+                    "patterns": [
+                        {
+                            "include": "#expression"
+                        }
+                    ]
+                },
+                {
+                    "begin": "\\(",
+                    "captures": [
+                        {
+                            "name": "punctuation.other.django"
+                        }
+                    ],
+                    "end": "\\)",
+                    "patterns": [
+                        {
+                            "include": "#expression"
+                        }
+                    ]
+                },
+                {
+                    "begin": "\\{",
+                    "captures": [
+                        {
+                            "name": "punctuation.other.django"
+                        }
+                    ],
+                    "end": "\\}",
+                    "patterns": [
+                        {
+                            "include": "#expression"
+                        }
+                    ]
+                },
+                {
+                    "match": "(\\.|:|\\||,)",
+                    "name": "punctuation.other.django"
+                },
+                {
+                    "match": "(==|<=|=>|<|>|!=)",
+                    "name": "keyword.operator.comparison.django"
+                },
+                {
+                    "match": "=",
+                    "name": "keyword.operator.assignment.django"
+                },
+                {
+                    "begin": "\"",
+                    "beginCaptures": [
+                        {
+                            "name": "punctuation.definition.string.begin.django"
+                        }
+                    ],
+                    "end": "\"",
+                    "endCaptures": [
+                        {
+                            "name": "punctuation.definition.string.end.django"
+                        }
+                    ],
+                    "name": "string.quoted.double.django",
+                    "patterns": [
+                        {
+                            "include": "#string"
+                        }
+                    ]
+                },
+                {
+                    "begin": "'",
+                    "beginCaptures": [
+                        {
+                            "name": "punctuation.definition.string.begin.django"
+                        }
+                    ],
+                    "end": "'",
+                    "endCaptures": [
+                        {
+                            "name": "punctuation.definition.string.end.django"
+                        }
+                    ],
+                    "name": "string.quoted.single.django",
+                    "patterns": [
+                        {
+                            "include": "#string"
+                        }
+                    ]
+                },
+                {
+                    "begin": "@\/",
+                    "beginCaptures": [
+                        {
+                            "name": "punctuation.definition.regexp.begin.django"
+                        }
+                    ],
+                    "end": "\/",
+                    "endCaptures": [
+                        {
+                            "name": "punctuation.definition.regexp.end.django"
+                        }
+                    ],
+                    "name": "string.regexp.django",
+                    "patterns": [
+                        {
+                            "include": "#simple_escapes"
+                        }
+                    ]
+                }
+            ]
+        },
+        "simple_escapes": {
+            "captures": {
+                "1": {
+                    "name": "constant.character.escape.newline.django"
+                },
+                "10": {
+                    "name": "constant.character.escape.tab.django"
+                },
+                "11": {
+                    "name": "constant.character.escape.vertical-tab.django"
+                },
+                "2": {
+                    "name": "constant.character.escape.backlash.django"
+                },
+                "3": {
+                    "name": "constant.character.escape.double-quote.django"
+                },
+                "4": {
+                    "name": "constant.character.escape.single-quote.django"
+                },
+                "5": {
+                    "name": "constant.character.escape.bell.django"
+                },
+                "6": {
+                    "name": "constant.character.escape.backspace.django"
+                },
+                "7": {
+                    "name": "constant.character.escape.formfeed.django"
+                },
+                "8": {
+                    "name": "constant.character.escape.linefeed.django"
+                },
+                "9": {
+                    "name": "constant.character.escape.return.django"
+                }
+            },
+            "match": "(\\\\\\n)|(\\\\\\\\)|(\\\\\\\")|(\\\\')|(\\\\a)|(\\\\b)|(\\\\f)|(\\\\n)|(\\\\r)|(\\\\t)|(\\\\v)"
+        },
+        "string": {
+            "patterns": [
+                {
+                    "include": "#simple_escapes"
+                },
+                {
+                    "include": "#escaped_char"
+                },
+                {
+                    "include": "#escaped_unicode_char"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Forking from the original package [django-template](https://github.com/iambibhas/vscode-django-template) because it's content is really useful, it looks like the project has been abandoned and your package, which by the way is in active development, can be improved with it. Also, this solves #3 