### PR TITLE
Corrects the reverse import for get_absolute_url()

### DIFF
--- a/snippets/models/methods.json
+++ b/snippets/models/methods.json
@@ -12,7 +12,7 @@
         "prefix": "get_absolute_url",
         "body": [
             "def get_absolute_url(self):",
-            "\tfrom django.core.urlresolvers import reverse",
+            "\tfrom django.urls import reverse",
             "\treturn reverse('$1', kwargs={'pk': self.pk})"
         ],
         "description": "",


### PR DESCRIPTION
In Django 2, the reverse method is now in django.urls and not in django.core.urlresolvers