### PR TITLE
Redo django-html syntax type

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Add this to settings to get Emmet support for your Django Templates
 }
 ```
 
+Add this to settings to get syntax highlighter
+
+```json
+"files.associations": {
+  "**/templates/*.html": "django-html"
+}
+```
+
 To enable format feature add:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Add this to settings to get Emmet support for your Django Templates
 }
 ```
 
+To enable format feature add:
+
+```json
+"[django-html]": {
+  "editor.defaultFormatter": "vscode.html-language-features",
+}
+```
+
 ## Features
 
 ### Snippets for Django Admin

--- a/syntaxes/django-html.json
+++ b/syntaxes/django-html.json
@@ -1,5 +1,5 @@
 {
-    "name": "html",
+    "name": "django-html",
     "scopeName": "text.html.django",
     "comment": "Django Template Engine",
     "fileTypes": [


### PR DESCRIPTION
Add django-html again in order to the user can enable format code feature also I update the documentation.

If we use the html (duplicated one the default one) the formatter (Format code) doesn't work.